### PR TITLE
DS-3897 harvesting fails on bistream ingestion

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
@@ -178,7 +178,7 @@ public class OREIngestionCrosswalk
             if (href != null) {
                 try {
                     // Make sure the url string escapes all the oddball characters
-                    String processedURL = encodeForURL(href);
+                    String processedURL = encodeForURL(href).replace("%20", "+");
                     // Generate a requeset for the aggregated resource
                     ARurl = new URL(processedURL);
                     in = ARurl.openStream();


### PR DESCRIPTION
While harvesting with bitstreams we fail to get an InputStream when filenames contain blanks. Those blanks have to be escaped with '+' instead of '%20' in order to find the files.